### PR TITLE
Refactor namespaces and update DictionaryDBContext

### DIFF
--- a/Roachagram.API/Controllers/AnagramController.cs
+++ b/Roachagram.API/Controllers/AnagramController.cs
@@ -7,8 +7,9 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Roachagram.API.BL;
+using Roachagram.API.Models;
 
-namespace AnagramAPI.Controllers
+namespace RoachagramAPI.Controllers
 {
     /// <summary>
     /// API Controller for handling anagram-related operations.

--- a/Roachagram.API/Models/AIModel.cs
+++ b/Roachagram.API/Models/AIModel.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace AnagramAPI.Models
+namespace RoachagramAPI.Models
 {
     /// <summary>
     /// 

--- a/Roachagram.API/Models/Models.cs
+++ b/Roachagram.API/Models/Models.cs
@@ -4,13 +4,17 @@ using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore;
 
 
-namespace AnagramAPI
+namespace Roachagram.API.Models
 {
     /// <summary>
     /// 
     /// </summary>
     /// <seealso cref="Microsoft.EntityFrameworkCore.DbContext" />
-    public class DictionaryDBContext : DbContext
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="DictionaryDBContext"/> class.
+    /// </remarks>
+    /// <param name="options">The options.</param>
+    public class DictionaryDBContext(DbContextOptions<DictionaryDBContext> options) : DbContext(options)
     {
         /// <summary>
         /// Gets or sets the dictionary.
@@ -19,15 +23,6 @@ namespace AnagramAPI
         /// The dictionary.
         /// </value>
         public DbSet<DictionaryDB> Dictionary { get; set; }
-
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DictionaryDBContext"/> class.
-        /// </summary>
-        /// <param name="options">The options.</param>
-        public DictionaryDBContext(DbContextOptions<DictionaryDBContext> options): base(options)
-        { 
-        }
 
         /// <summary>
         /// Override this method to further configure the model that was discovered by convention from the entity types

--- a/Roachagram.API/Startup.cs
+++ b/Roachagram.API/Startup.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Roachagram.API;
+using RoachagramAPI;
 using Azure.Core;
 using Azure.Security.KeyVault.Secrets;
 using Microsoft.AspNetCore.Builder;
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Roachagram.API.Models;
 
 namespace Roachagram.API
 {


### PR DESCRIPTION
- Changed namespaces from `AnagramAPI` to `RoachagramAPI` for `AnagramController`, `AIModel`, and `Models` classes.
- Added `using` directive for `Roachagram.API.Models` in `AnagramController.cs` and `Startup.cs`.
- Modified `DictionaryDBContext` constructor in `Models.cs` to improve database context configuration.
- Updated comments in `Models.cs` for clearer documentation.