### PR TITLE
Implement rate limiting middleware for device requests

### DIFF
--- a/Roachagram.API/Extensions/MiddlewareExtensions.cs
+++ b/Roachagram.API/Extensions/MiddlewareExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Roachagram.API.Middleware;
+
+namespace Roachagram.API.Extensions
+{
+    /// <summary>
+    /// Extension methods for middleware registration.
+    /// </summary>
+    public static class MiddlewareExtensions
+    {
+        /// <summary>
+        /// Adds the RateLimitingMiddleware to the application's request pipeline.
+        /// </summary>
+        /// <param name="builder">The application builder.</param>
+        /// <param name="slidingExpiration">The sliding expiration time for rate limiting.</param>
+        /// <returns>The application builder.</returns>
+        public static IApplicationBuilder UseRateLimiting(this IApplicationBuilder builder, TimeSpan slidingExpiration)
+        {
+            var cache = builder.ApplicationServices.GetRequiredService<IMemoryCache>();
+            return builder.UseMiddleware<RateLimitingMiddleware>(cache, slidingExpiration);
+        }
+    }
+}

--- a/Roachagram.API/Middleware/RateLimitingMiddlewarecs.cs
+++ b/Roachagram.API/Middleware/RateLimitingMiddlewarecs.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Roachagram.API.Middleware
+{
+    // Middleware to enforce rate limiting based on a device ID provided in the request header
+    public class RateLimitingMiddleware(RequestDelegate next, IMemoryCache cache, TimeSpan slidingExpiration)
+    {
+        // The next middleware in the pipeline
+        private readonly RequestDelegate _next = next;
+
+        // In-memory cache to store rate-limiting information
+        private readonly IMemoryCache _cache = cache;
+
+        // Sliding expiration time for cache entries
+        private readonly TimeSpan _slidingExpiration = slidingExpiration;
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            // Retrieve the device ID from the request headers
+            var deviceId = context.Request.Headers["X-Device-ID"].FirstOrDefault();
+
+            // If the device ID is missing, return a 400 Bad Request response
+            if (string.IsNullOrEmpty(deviceId))
+            {
+                context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                await context.Response.WriteAsync("Missing X-Device-ID header.");
+                return;
+            }
+
+            // Generate a unique cache key for the device ID
+            var cacheKey = $"RateLimit-{deviceId}";
+
+            // Check if the device ID is already in the cache
+            if (!_cache.TryGetValue(cacheKey, out _))
+            {
+                // If not in the cache, add it with a sliding expiration
+                var cacheEntryOptions = new MemoryCacheEntryOptions
+                {
+                    SlidingExpiration = _slidingExpiration
+                };
+
+                _cache.Set(cacheKey, true, cacheEntryOptions);
+            }
+            else
+            {
+                // If the device ID is in the cache, return a 429 Too Many Requests response
+                context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+                await context.Response.WriteAsync("Rate limit exceeded. Please try again later.");
+                return;
+            }
+
+            // Proceed to the next middleware in the pipeline
+            await _next(context);
+        }
+    }
+}

--- a/Roachagram.API/Startup.cs
+++ b/Roachagram.API/Startup.cs
@@ -10,6 +10,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Roachagram.API.Models;
+using Microsoft.AspNetCore.Http;
+using System.Linq;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace Roachagram.API
 {
@@ -100,6 +103,48 @@ namespace Roachagram.API
 
             // Adds authorization middleware to the request pipeline.
             app.UseAuthorization();
+
+            // Adds rate limiting middleware based on the "X-Device-ID" header.
+            app.Use(async (context, next) =>
+            {
+                // Retrieve the "X-Device-ID" header from the request.
+                var deviceId = context.Request.Headers["X-Device-ID"].FirstOrDefault();
+
+                // Check if the deviceId is present.
+                if (string.IsNullOrEmpty(deviceId))
+                {
+                    // Respond with 400 Bad Request if the header is missing.
+                    context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    await context.Response.WriteAsync("Missing X-Device-ID header.");
+                    return;
+                }
+
+                // Implement rate limiting logic here (e.g., check a cache or database for request limits).
+                // Add the deviceId to a cache with a sliding expiration.
+                var cache = app.ApplicationServices.GetRequiredService<IMemoryCache>();
+                var cacheKey = $"RateLimit-{deviceId}";
+
+                // Check if the deviceId is already in the cache.
+                if (!cache.TryGetValue(cacheKey, out _))
+                {
+                    // Add the deviceId to the cache with a sliding expiration of 5 seconds.
+                    var cacheEntryOptions = new MemoryCacheEntryOptions
+                    {
+                        SlidingExpiration = TimeSpan.FromSeconds(5)
+                    };
+
+                    cache.Set(cacheKey, true, cacheEntryOptions);
+                }
+                else
+                {
+                    // Respond with 429 Too Many Requests if the deviceId is already in the cache.
+                    context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+                    await context.Response.WriteAsync("Rate limit exceeded. Please try again later.");
+                    return;
+                }
+                
+                await next.Invoke();
+            });
 
             // Configures the endpoints for the application.
             app.UseEndpoints(endpoints =>

--- a/Roachagram.API/Startup.cs
+++ b/Roachagram.API/Startup.cs
@@ -1,18 +1,19 @@
 ﻿using System;
-using RoachagramAPI;
+using System.Linq;
 using Azure.Core;
 using Azure.Security.KeyVault.Secrets;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Roachagram.API.Extensions;
 using Roachagram.API.Models;
-using Microsoft.AspNetCore.Http;
-using System.Linq;
-using Microsoft.Extensions.Caching.Memory;
+using RoachagramAPI;
 
 namespace Roachagram.API
 {
@@ -104,47 +105,7 @@ namespace Roachagram.API
             // Adds authorization middleware to the request pipeline.
             app.UseAuthorization();
 
-            // Adds rate limiting middleware based on the "X-Device-ID" header.
-            app.Use(async (context, next) =>
-            {
-                // Retrieve the "X-Device-ID" header from the request.
-                var deviceId = context.Request.Headers["X-Device-ID"].FirstOrDefault();
-
-                // Check if the deviceId is present.
-                if (string.IsNullOrEmpty(deviceId))
-                {
-                    // Respond with 400 Bad Request if the header is missing.
-                    context.Response.StatusCode = StatusCodes.Status400BadRequest;
-                    await context.Response.WriteAsync("Missing X-Device-ID header.");
-                    return;
-                }
-
-                // Implement rate limiting logic here (e.g., check a cache or database for request limits).
-                // Add the deviceId to a cache with a sliding expiration.
-                var cache = app.ApplicationServices.GetRequiredService<IMemoryCache>();
-                var cacheKey = $"RateLimit-{deviceId}";
-
-                // Check if the deviceId is already in the cache.
-                if (!cache.TryGetValue(cacheKey, out _))
-                {
-                    // Add the deviceId to the cache with a sliding expiration of 5 seconds.
-                    var cacheEntryOptions = new MemoryCacheEntryOptions
-                    {
-                        SlidingExpiration = TimeSpan.FromSeconds(5)
-                    };
-
-                    cache.Set(cacheKey, true, cacheEntryOptions);
-                }
-                else
-                {
-                    // Respond with 429 Too Many Requests if the deviceId is already in the cache.
-                    context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
-                    await context.Response.WriteAsync("Rate limit exceeded. Please try again later.");
-                    return;
-                }
-                
-                await next.Invoke();
-            });
+            app.UseRateLimiting(TimeSpan.FromSeconds(5));
 
             // Configures the endpoints for the application.
             app.UseEndpoints(endpoints =>


### PR DESCRIPTION
Added middleware to enforce rate limiting based on the "X-Device-ID" header. The middleware checks for the header's presence, responds with a 400 Bad Request if missing, and uses a sliding expiration cache to limit requests from the same device. If the rate limit is exceeded, a 429 Too Many Requests response is returned.