### PR TITLE
Add health check endpoint and update rate limiting logic

### DIFF
--- a/Roachagram.API/Controllers/HomeController.cs
+++ b/Roachagram.API/Controllers/HomeController.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Roachagram.API.Controllers
+{
+    [Route("api/home")]
+    [ApiController]
+    public class HomeController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Get()
+        {
+            return Ok("Roachagram API is running.");
+        }
+    }
+}

--- a/Roachagram.API/Middleware/RateLimitingMiddlewarecs.cs
+++ b/Roachagram.API/Middleware/RateLimitingMiddlewarecs.cs
@@ -20,6 +20,14 @@ namespace Roachagram.API.Middleware
 
         public async Task InvokeAsync(HttpContext context)
         {
+            // Skip rate limiting for health check endpoints
+            if (context.Request.Path.StartsWithSegments("/api/home", StringComparison.OrdinalIgnoreCase) ||
+                context.Request.Path.StartsWithSegments("/health", StringComparison.OrdinalIgnoreCase))
+            {
+                await _next(context);
+                return;
+            }
+
             // Retrieve the device ID from the request headers
             var deviceId = context.Request.Headers["X-Device-ID"].FirstOrDefault();
 


### PR DESCRIPTION
Added HomeController with /api/home GET endpoint for health checks. Updated RateLimitingMiddleware to skip rate limiting for /api/home and /health endpoints. Added dictionary.bak binary file.